### PR TITLE
Update status to include locked days

### DIFF
--- a/elf/models.py
+++ b/elf/models.py
@@ -153,6 +153,7 @@ class DayStatus(BaseModel):
     stars: int = Field(..., ge=0, le=2)
     href: str
     aria_label: str
+    is_locked: bool
 
     model_config = {
         "frozen": True,  # makes objects hashable/immutable

--- a/elf/status.py
+++ b/elf/status.py
@@ -230,7 +230,9 @@ def build_year_status_table(status: YearStatus) -> Table:
 
     for day in sorted(status.days, key=lambda d: d.day):
         # Render stars as a 2-star gauge: ★ for earned, ☆ for missing
-        stars_str = "★" * day.stars + "☆" * (2 - day.stars)
+        stars_str = (
+            "★" * day.stars + "☆" * (2 - day.stars) if not day.is_locked else "🔒"
+        )
 
         # Row coloring based on completion
         if day.stars == 2:

--- a/elf/status.py
+++ b/elf/status.py
@@ -132,7 +132,7 @@ def _stars_from_aria_and_classes(
     return 0
 
 
-def _parse_day_status(element: Tag) -> DayStatus | None:
+def _parse_day_status(element: Tag, *, is_locked: bool) -> DayStatus | None:
     aria_label = element.get("aria-label", "") or ""
     aria_label_str = str(aria_label) if aria_label else None
 
@@ -164,6 +164,7 @@ def _parse_day_status(element: Tag) -> DayStatus | None:
         stars=stars,
         href=href,
         aria_label=str(aria_label) if aria_label else "",
+        is_locked=is_locked,
     )
 
 
@@ -191,9 +192,15 @@ def parse_year_status(html: str) -> YearStatus:
 
     day_statuses: list[DayStatus] = []
 
-    # Each day is an <a> with class "calendar-dayN"
+    # Each unlocked day is an <a> with class "calendar-dayN"
     for a in calendar.select("a[class^='calendar-day']"):
-        day_status = _parse_day_status(a)
+        day_status = _parse_day_status(a, is_locked=False)
+        if day_status:
+            day_statuses.append(day_status)
+
+    # Each locked day is an <span> with class "calendar-dayN"
+    for span in calendar.select("span[class^='calendar-day']"):
+        day_status = _parse_day_status(span, is_locked=True)
         if day_status:
             day_statuses.append(day_status)
 

--- a/elf/status.py
+++ b/elf/status.py
@@ -132,6 +132,41 @@ def _stars_from_aria_and_classes(
     return 0
 
 
+def _parse_day_status(element: Tag) -> DayStatus | None:
+    aria_label = element.get("aria-label", "") or ""
+    aria_label_str = str(aria_label) if aria_label else None
+
+    # Try day number from aria-label first
+    day_num: int | None = None
+    m = re.search(r"Day\s+(\d+)", str(aria_label))
+    if m:
+        day_num = int(m.group(1))
+
+    if day_num is None:
+        # Fallback to the inner span with class "calendar-day"
+        day_span = element.select_one(".calendar-day")
+        if not day_span:
+            return None
+        day_num = int(day_span.get_text(strip=True))
+
+    href_raw = element.get("href", "")
+    href = str(href_raw) if href_raw else ""
+
+    classes = element.get("class") or []
+    if isinstance(classes, str):
+        classes = classes.split()
+    elif not isinstance(classes, list):
+        classes = list(classes) if classes else []
+    stars = _stars_from_aria_and_classes(aria_label_str, classes)
+
+    return DayStatus(
+        day=day_num,
+        stars=stars,
+        href=href,
+        aria_label=str(aria_label) if aria_label else "",
+    )
+
+
 def parse_year_status(html: str) -> YearStatus:
     soup = BeautifulSoup(html, "html.parser")
 
@@ -158,40 +193,9 @@ def parse_year_status(html: str) -> YearStatus:
 
     # Each day is an <a> with class "calendar-dayN"
     for a in calendar.select("a[class^='calendar-day']"):
-        aria_label = a.get("aria-label", "") or ""
-        aria_label_str = str(aria_label) if aria_label else None
-
-        # Try day number from aria-label first
-        day_num: int | None = None
-        m = re.search(r"Day\s+(\d+)", str(aria_label))
-        if m:
-            day_num = int(m.group(1))
-
-        if day_num is None:
-            # Fallback to the inner span with class "calendar-day"
-            day_span = a.select_one(".calendar-day")
-            if not day_span:
-                continue
-            day_num = int(day_span.get_text(strip=True))
-
-        href_raw = a.get("href", "")
-        href = str(href_raw) if href_raw else ""
-
-        classes = a.get("class") or []
-        if isinstance(classes, str):
-            classes = classes.split()
-        elif not isinstance(classes, list):
-            classes = list(classes) if classes else []
-        stars = _stars_from_aria_and_classes(aria_label_str, classes)
-
-        day_statuses.append(
-            DayStatus(
-                day=day_num,
-                stars=stars,
-                href=href,
-                aria_label=str(aria_label) if aria_label else "",
-            )
-        )
+        day_status = _parse_day_status(a)
+        if day_status:
+            day_statuses.append(day_status)
 
     # Sort by day number to be safe
     day_statuses.sort(key=lambda d: d.day)

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -1,3 +1,4 @@
+from elf import DayStatus
 from elf.leaderboard import format_leaderboard_as_table
 from elf.models import Leaderboard
 from elf.status import build_year_status_table, parse_login_state, parse_year_status
@@ -64,6 +65,9 @@ def test_status_parsing_handles_basic_calendar_html():
         <a class="calendar-day3" aria-label="Day 3">
           <span class="calendar-day">3</span>
         </a>
+        <span aria-hidden="true" class="calendar-day4">
+            <span class="calendar-day">4</span>
+        </span>
       </pre>
       <a href="/settings">Settings</a>
     </html>
@@ -74,8 +78,15 @@ def test_status_parsing_handles_basic_calendar_html():
     status = parse_year_status(html)
     assert status.year == 2025
     assert status.total_stars == 5
-    assert len(status.days) == 3
+    assert len(status.days) == 4
+
+    assert [(day.day, day.stars, day.is_locked) for day in status.days] == [
+        (1, 2, False),
+        (2, 1, False),
+        (3, 0, False),
+        (4, 0, True),
+    ]
 
     table = build_year_status_table(status)
-    assert table.row_count == 3
+    assert table.row_count == 4
     assert table.title and "2025" in table.title


### PR DESCRIPTION
This PR updates the status query to return locked days too. 

For a dashboard I'm building I need a way to differentiate days where there is no puzzle (relevant for 2025 since there are only 12 days) vs. days where there is a puzzle but no stars are earned yet. One way to support this is to add locked days to the status list - this way status gives visibility into all puzzles for a year. This change seems like it could be generally useful for others too.

**Before:**

<img width="200" alt="Screenshot 2025-12-07 at 14 37 25" src="https://github.com/user-attachments/assets/23029fb2-3e0c-49b0-9c04-3230310a2ef6" />

**After:**

<img width="200" alt="Screenshot 2025-12-07 at 16 37 51" src="https://github.com/user-attachments/assets/2edde56c-b524-414a-b2ee-14e76d1148cc" />

